### PR TITLE
ajusta configuração das legendas para tornalas distintas do texto principal

### DIFF
--- a/meta.tex
+++ b/meta.tex
@@ -75,7 +75,8 @@
 %\graphicspath{{./figuras/}}
 
 % Customizar as legendas de figuras e tabelas
-\usepackage{caption}
+% Corsi - torna longas legendas distintas do texto principal 
+\usepackage[margin=40pt,font=small,labelfont=bf,labelsep=endash,justification=justified]{caption}
 
 % Criar ambientes com 2 ou mais colunas
 \usepackage{multicol}


### PR DESCRIPTION
As longas legendas estavam confundindo com o texto, usei essa configuração para melhorar a visualização.
